### PR TITLE
publish fix for the map

### DIFF
--- a/script.js
+++ b/script.js
@@ -66,7 +66,7 @@ var elements = {
 
 elements.expand.onclick = function () {
     elements.collapsed.style.maxHeight = '0%'
-    elements.expanded.style.maxHeight = '200%'
+    elements.expanded.style.maxHeight = '1000%'
 }
 
 elements.collapse.onclick = function () {


### PR DESCRIPTION
Guck das mal bitte durch Oli. Das Problem war, dass beim Ausfahren der Infos die maximale Höhe von 0% (nicht angezeigt) auf 200% der ursprünglichen Höhe erhöht wurde. Das reicht nicht mehr für das Bild (die Karte). Ich hab das jetzt auf 1000% erhöht.

Wenn die Animation zu schnell ist könnte man da nochmal dran arbeiten. Was denkst du?
